### PR TITLE
fix(stusds): stop done() false-complete on de-auth

### DIFF
--- a/src/stusds/StUsdsRateSetterDissBudSpell.sol
+++ b/src/stusds/StUsdsRateSetterDissBudSpell.sol
@@ -54,27 +54,24 @@ contract StUsdsRateSetterDissBudSpell is DssEmergencySpell {
     /**
      * @notice Returns whether the spell is done or not.
      * @dev Checks if the bud has been dissed from the rate setter.
-     *      The spell would revert if any of the following conditions holds:
+     *      Authorization (`wards`) is not treated as completion: de-authorizing rateSetter/mom
+     *      must not mark an incomplete dissBud as done. Calls that revert are still treated as
+     *      "not a StUsds / RateSetter instance" (N/A → done).
+     *      Note: the spell would revert on cast if any of the following holds:
      *          1. stUsdsRateSetter is not ward on stUsds;
      *          2. stUsdsMom is not ward on stUsdsRateSetter.
-     *      In both cases, it returns `true`, meaning no further action can be taken at the moment.
      */
     function done() external view returns (bool) {
-        try stUsds.wards(address(stUsdsRateSetter)) returns (uint256 ward) {
-            // Ignore StUsds instances that have not relied on StUsdsRateSetter.
-            if (ward == 0) {
-                return true;
-            }
+        // Shape checks only — do not interpret ward==0 as success (false-complete after de-auth).
+        try stUsds.wards(address(stUsdsRateSetter)) {
+            // Authorization state is irrelevant to completion; outcomes below decide.
         } catch {
             // If the call failed, it means the contract is most likely not a StUsds instance.
             return true;
         }
 
-        try stUsdsRateSetter.wards(address(stUsdsMom)) returns (uint256 ward) {
-            // Ignore StUsdsRateSetter instances that have not relied on StUsdsMom.
-            if (ward == 0) {
-                return true;
-            }
+        try stUsdsRateSetter.wards(address(stUsdsMom)) {
+            // Authorization state is irrelevant to completion; outcomes below decide.
         } catch {
             // If the call failed, it means the contract is most likely not a RateSetter instance.
             return true;

--- a/src/stusds/StUsdsRateSetterDissBudSpell.t.integration.sol
+++ b/src/stusds/StUsdsRateSetterDissBudSpell.t.integration.sol
@@ -94,7 +94,7 @@ contract StUsdsRateSetterDissBudSpellTest is DssTest {
         vm.prank(pauseProxy);
         stUsds.deny(address(stUsdsRateSetter));
 
-        assertTrue(spell.done(), "spell not done");
+        assertFalse(spell.done(), "spell unexpectedly done after de-auth");
     }
 
     function testDoneWhenStUsdsMomIsNotWardInStUsdsRateSetter() public {
@@ -102,7 +102,18 @@ contract StUsdsRateSetterDissBudSpellTest is DssTest {
         vm.prank(pauseProxy);
         stUsdsRateSetter.deny(stUsdsMom);
 
-        assertTrue(spell.done(), "spell not done");
+        assertFalse(spell.done(), "spell unexpectedly done after de-auth");
+    }
+
+    function testDoneWhenDeauthAfterDissBudComplete() public {
+        stdstore.target(address(stUsdsRateSetter)).sig("buds(address)").with_key(bud).checked_write(uint256(0));
+        assertTrue(spell.done(), "spell not done after dissBud");
+
+        address pauseProxy = dss.chainlog.getAddress("MCD_PAUSE_PROXY");
+        vm.prank(pauseProxy);
+        stUsds.deny(address(stUsdsRateSetter));
+
+        assertTrue(spell.done(), "spell not done after de-auth with dissBud complete");
     }
 
     // Revert wards

--- a/src/stusds/StUsdsRateSetterHaltSpell.sol
+++ b/src/stusds/StUsdsRateSetterHaltSpell.sol
@@ -48,27 +48,24 @@ contract StUsdsRateSetterHaltSpell is DssEmergencySpell {
     /**
      * @notice Returns whether the spell is done or not.
      * @dev Checks if the bad has been set to 1 for the stUsdsRateSetter.
-     *      The spell would revert if any of the following conditions holds:
+     *      Authorization (`wards`) is not treated as completion: de-authorizing rateSetter/mom
+     *      must not mark an incomplete halt as done. Calls that revert are still treated as
+     *      "not a StUsds / RateSetter instance" (N/A → done).
+     *      Note: the spell would revert on cast if any of the following holds:
      *          1. stUsdsRateSetter is not ward on stUsds;
      *          2. stUsdsMom is not ward on stUsdsRateSetter.
-     *      In both cases, it returns `true`, meaning no further action can be taken at the moment.
      */
     function done() external view returns (bool) {
-        try stUsds.wards(address(stUsdsRateSetter)) returns (uint256 ward) {
-            // Ignore StUsds instances that have not relied on StUsdsRateSetter.
-            if (ward == 0) {
-                return true;
-            }
+        // Shape checks only — do not interpret ward==0 as success (false-complete after de-auth).
+        try stUsds.wards(address(stUsdsRateSetter)) {
+            // Authorization state is irrelevant to completion; outcomes below decide.
         } catch {
             // If the call failed, it means the contract is most likely not a StUsds instance.
             return true;
         }
 
-        try stUsdsRateSetter.wards(address(stUsdsMom)) returns (uint256 ward) {
-            // Ignore StUsdsRateSetter instances that have not relied on StUsdsMom.
-            if (ward == 0) {
-                return true;
-            }
+        try stUsdsRateSetter.wards(address(stUsdsMom)) {
+            // Authorization state is irrelevant to completion; outcomes below decide.
         } catch {
             // If the call failed, it means the contract is most likely not a RateSetter instance.
             return true;

--- a/src/stusds/StUsdsRateSetterHaltSpell.t.integration.sol
+++ b/src/stusds/StUsdsRateSetterHaltSpell.t.integration.sol
@@ -90,14 +90,24 @@ contract StUsdsRateSetterHaltSpellTest is DssTest {
         vm.prank(pauseProxy);
         stUsds.deny(address(stUsdsRateSetter));
 
-        assertTrue(spell.done(), "spell not done");
+        assertFalse(spell.done(), "spell unexpectedly done after de-auth");
     }
 
     function testDoneWhenStUsdsMomIsNotWardInStUsdsRateSetter() public {
         vm.prank(pauseProxy);
         stUsdsRateSetter.deny(stUsdsMom);
 
-        assertTrue(spell.done(), "spell not done");
+        assertFalse(spell.done(), "spell unexpectedly done after de-auth");
+    }
+
+    function testDoneWhenDeauthAfterHaltComplete() public {
+        stdstore.target(address(stUsdsRateSetter)).sig("bad()").checked_write(uint256(1));
+        assertTrue(spell.done(), "spell not done after halt");
+
+        vm.prank(pauseProxy);
+        stUsds.deny(address(stUsdsRateSetter));
+
+        assertTrue(spell.done(), "spell not done after de-auth with halt complete");
     }
 
     function testDoneWhenStUsdsToRateSetterWardReverts() public {

--- a/src/stusds/StUsdsWipeParamSpell.sol
+++ b/src/stusds/StUsdsWipeParamSpell.sol
@@ -94,36 +94,30 @@ contract StUsdsWipeParamSpell is DssEmergencySpell {
     /**
      * @notice Returns whether the spell is done or not.
      * @dev Checks if the line or cap have been zeroed on the stUSDS.
-     *      The spell would revert if any of the following conditions holds:
+     *      Authorization (`wards`) is not treated as completion: de-authorizing mom/rateSetter
+     *      must not mark an incomplete wipe as done. Calls that revert are still treated as
+     *      "not a StUsds / RateSetter instance" (N/A → done).
+     *      Note: the spell would revert on cast if any of the following holds:
      *          1. stUsdsMom is not a ward of stUsds;
      *          2. stUsdsRateSetter is not a ward of stUsds;
      *          3. stUsdsMom is not a ward of stUsdsRateSetter.
      */
     function done() external view returns (bool) {
-        try stUsds.wards(address(stUsdsMom)) returns (uint256 ward) {
-            // Ignore StUsds instances that have not relied on StUsdsMom.
-            if (ward == 0) {
-                return true;
-            }
+        // Shape checks only — do not interpret ward==0 as success (false-complete after de-auth).
+        try stUsds.wards(address(stUsdsMom)) {
+            // Authorization state is irrelevant to completion; outcomes below decide.
         } catch {
             // If the call failed, it means the contract is most likely not a StUsds instance.
             return true;
         }
-        try stUsds.wards(address(stUsdsRateSetter)) returns (uint256 ward) {
-            // Ignore StUsds instances that have not relied on stUsdsRateSetter.
-            if (ward == 0) {
-                return true;
-            }
+        try stUsds.wards(address(stUsdsRateSetter)) {
+            // Authorization state is irrelevant to completion; outcomes below decide.
         } catch {
             // If the call failed, it means the contract is most likely not a StUsds instance.
             return true;
         }
-
-        try stUsdsRateSetter.wards(address(stUsdsMom)) returns (uint256 ward) {
-            // Ignore StUsdsRateSetter instances that have not relied on StUsdsMom.
-            if (ward == 0) {
-                return true;
-            }
+        try stUsdsRateSetter.wards(address(stUsdsMom)) {
+            // Authorization state is irrelevant to completion; outcomes below decide.
         } catch {
             // If the call failed, it means the contract is most likely not a RateSetter instance.
             return true;

--- a/src/stusds/StUsdsWipeParamSpell.t.integration.sol
+++ b/src/stusds/StUsdsWipeParamSpell.t.integration.sol
@@ -136,6 +136,20 @@ contract SingleLineOrCapWipeSpellTest is DssTest {
         _checkDoneWhenStUsdsMomIsNotWardInStUsdsRateSetter(Param.BOTH);
     }
 
+    // De-auth after successful wipe still reports done (outcomes-based)
+
+    function testDoneWhenDeauthAfterWipeCompleteCap() public {
+        _checkDoneWhenDeauthAfterWipeComplete(Param.CAP);
+    }
+
+    function testDoneWhenDeauthAfterWipeCompleteLine() public {
+        _checkDoneWhenDeauthAfterWipeComplete(Param.LINE);
+    }
+
+    function testDoneWhenDeauthAfterWipeCompleteBoth() public {
+        _checkDoneWhenDeauthAfterWipeComplete(Param.BOTH);
+    }
+
     // Revert with no Hat
 
     function testRevertSpellWhenItDoesNotHaveTheHatLine() public {
@@ -315,7 +329,7 @@ contract SingleLineOrCapWipeSpellTest is DssTest {
         vm.prank(pauseProxy);
         stUsds.deny(stUsdsMom);
 
-        assertTrue(spell.done(), "spell not done");
+        assertFalse(spell.done(), "spell unexpectedly done after de-auth");
     }
 
     function _checkDoneWhenStUsdsRateSetterIsNotWardInStUsds(Param param) internal {
@@ -325,7 +339,7 @@ contract SingleLineOrCapWipeSpellTest is DssTest {
         vm.prank(pauseProxy);
         stUsds.deny(address(stUsdsRateSetter));
 
-        assertTrue(spell.done(), "spell not done");
+        assertFalse(spell.done(), "spell unexpectedly done after de-auth");
     }
 
     function _checkDoneWhenStUsdsMomIsNotWardInStUsdsRateSetter(Param param) internal {
@@ -335,7 +349,35 @@ contract SingleLineOrCapWipeSpellTest is DssTest {
         vm.prank(pauseProxy);
         stUsdsRateSetter.deny(stUsdsMom);
 
-        assertTrue(spell.done(), "spell not done");
+        assertFalse(spell.done(), "spell unexpectedly done after de-auth");
+    }
+
+    function _checkDoneWhenDeauthAfterWipeComplete(Param param) internal {
+        StUsdsWipeParamSpell spell = StUsdsWipeParamSpell(factory.deploy(param));
+        bytes32 ilk = spell.stUsds().ilk();
+        (uint256 art, uint256 rate, uint256 spot,, uint256 dust) = spell.vat().ilks(ilk);
+
+        if (param == Param.CAP || param == Param.BOTH) {
+            stdstore.target(address(spell.stUsds())).sig("cap()").checked_write(uint256(0));
+            stdstore.target(address(spell.stUsdsRateSetter())).sig("maxCap()").checked_write(uint256(0));
+        }
+        if (param == Param.LINE || param == Param.BOTH) {
+            vm.mockCall(
+                address(spell.vat()),
+                abi.encodeWithSelector(VatLike.ilks.selector, ilk),
+                abi.encode(art, rate, spot, uint256(0), dust)
+            );
+            stdstore.target(address(spell.stUsds())).sig("line()").checked_write(uint256(0));
+            stdstore.target(address(spell.stUsdsRateSetter())).sig("maxLine()").checked_write(uint256(0));
+        }
+
+        assertTrue(spell.done(), "spell not done after wipe");
+
+        address pauseProxy = dss.chainlog.getAddress("MCD_PAUSE_PROXY");
+        vm.prank(pauseProxy);
+        stUsds.deny(stUsdsMom);
+
+        assertTrue(spell.done(), "spell not done after de-auth with wipe complete");
     }
 
     function _checkRevertSpellWhenItDoesNotHaveTheHat(Param param) internal {


### PR DESCRIPTION
Fixes #34

## Summary
- `StUsdsWipeParamSpell.done()`, `StUsdsRateSetterHaltSpell.done()`, and `StUsdsRateSetterDissBudSpell.done()` no longer return `true` merely because the spell has lost `wards` / cannot act.
- Completion is based on outcomes (`cap`/`line`/`maxCap`/`maxLine`/`vat` line; `bad==1`; `buds(bud)==0`), so monitoring cannot false-complete after de-auth.
- Updates deny-path tests to expect `done() == false` when outcomes remain incomplete; adds de-auth-after-complete cases for Wipe, Halt, and DissBud siblings (stUSDS cohort).

## Test plan
- [x] `forge build`
- [ ] Review `done()` logic vs issue #34
- [ ] Optional: fork tests with `ETH_RPC_URL` if maintainers want


Made with [Cursor](https://cursor.com)